### PR TITLE
update minimum go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Direct Connect hub implementation for ADC and NMDC protocols.
 
-Requires Go 1.11+.
+Requires Go 1.12+.
 
 **Features:**
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/direct-connect/go-dcpp
 
+go 1.12
+
 require (
 	github.com/DataDog/zstd v1.4.0 // indirect
 	github.com/Shopify/go-lua v0.0.0-20181106184032-48449c60c0a9


### PR DESCRIPTION
hi, due to the code in hub/plugins/hubstats/hubstats.go:84 , the hub can now be compiled only with Go 1.12+.
