### PR TITLE
hub/adc: correctly propagate peer IP before routing a DCTM

### DIFF
--- a/hub/hub_adc.go
+++ b/hub/hub_adc.go
@@ -1108,7 +1108,7 @@ func (p *adcPeer) ConnectTo(peer Peer, addr string, token string, secure bool) e
 	} else {
 		field = [2]byte{'I', '6'} // IPv6
 	}
-	err = p.SendADCInfo(adc.UserMod{
+	err = p.SendADCBroadcast(peer.SID(), &adc.UserMod{
 		field: host,
 	})
 	if err != nil {


### PR DESCRIPTION
When go-dcpp receives a DCTM:
1) it sends to the recipient the fake info that the sender has updated its IP
2) then, it propagates the DCTM

The problem is that the fake IP update is not done correctly, as it is sent through an IINF, that is intended for updating Hub infos, not user ones, resulting in:
```
IINF I4192.168.8.8
DCTM ....
```

The IINF does not even contain the sender session ID. The procedure should be done with a BINF, that is intended for updating user infos (even if they're not really broadcasted) and contains the sender session ID:
```
BINF SESSIONID I4192.168.8.8
DCTM ....
```

This should fix the problem.

