### PR TITLE
Add automatic docker build (and fix build)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,0 +1,13 @@
+name: Docker Image CI
+
+# Trigger the workflow on push or pull request
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag go-dcpp:$(date +%s)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,76 @@
+### Build stage ###
+FROM golang:1.12-alpine AS build
+
+RUN \
+echo "**** install build dependencies ****" && \
+apk add --no-cache gcc git musl-dev && \
+mkdir /app
+
+WORKDIR /app
+
+# When building from the gohub repository, just copy it in
+copy . .
+# When building from outside the gohub repository, grab the source
+#RUN git clone --depth=1 https://github.com/direct-connect/go-dcpp.git .
+
+# Get dependencies
+RUN \
+echo "**** Install docker start script ****" && \
+mv -v start-docker.sh /bin/go-dcpp && \
+echo "**** get go dependencies ****" && \
+go get -d -v ./... && \
+echo "**** build and install GoHub ****" && \
+go install -v ./...
+
+# Whether to run the go-dcpp tests (0 = no, 1 = yes)
+ARG RUN_TESTS
+ENV RUN_TESTS=${RUN_TESTS}
+
+# The tests are currently flaky, so skip them by default
+RUN \
+if [ "${RUN_TESTS:-0}" = "1" ]; then \
+echo "**** Testing GoHub ****" && \
+go test ./...; \
+else \
+echo "**** Skipping GoHub Tests ****"; \
+fi
+
+
+### Final container stage ###
+FROM alpine:latest
+
+LABEL description="GoHub Direct Connect Hub"
+
+RUN \
+echo "**** install dependencies ****" && \
+apk add --no-cache pwgen && \
+echo "**** create config directory ****" && \
+mkdir /config
+
+WORKDIR /config
+VOLUME /config
+
+# The GoHub port (TCP)
+EXPOSE 1411
+
+# The HubStats port (TCP), be careful exposing this to the internet
+EXPOSE 2112
+
+# The default admin username and password (only used on the first run)
+ENV ADMIN_USER="admin"
+# Empty password means generate a random password on the first run
+ENV ADMIN_PASSWORD=""
+
+# The arguments to pass to go-hub serve
+CMD []
+ENTRYPOINT ["go-dcpp"]
+
+# Run this command periodically to make sure everything is working
+# Disabled by default since it clogs up the container logs
+#HEALTHCHECK CMD dcping ping 127.0.0.1:1411
+
+# Copy go-hub and dcping from the build stage
+COPY --from=build /go/bin/dcping /go/bin/go-hub /bin/go-dcpp /bin/
+
+# The GoHub user and group to run as (change with docker run -u)
+USER 888:888

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ### Build stage ###
-FROM golang:1.12-alpine AS build
+FROM golang:1.12-alpine3.11 AS build
 
 RUN \
 echo "**** install build dependencies ****" && \
@@ -7,6 +7,13 @@ apk add --no-cache gcc git musl-dev && \
 mkdir /app
 
 WORKDIR /app
+
+# Copy go.mod and go.sum and get *most* of the dependecies. Do it separately
+# before copying everything so it can be cached for faster rebuilds.
+COPY go.* ./
+RUN \
+echo "**** get go dependencies ****" && \
+go get -d -v ./...
 
 # When building from the gohub repository, just copy it in
 copy . .
@@ -16,9 +23,7 @@ copy . .
 # Get dependencies
 RUN \
 echo "**** Install docker start script ****" && \
-mv -v start-docker.sh /bin/go-dcpp && \
-echo "**** get go dependencies ****" && \
-go get -d -v ./... && \
+mv -v start-docker.sh /bin/go-dcpp.sh && \
 echo "**** build and install GoHub ****" && \
 go install -v ./...
 
@@ -37,7 +42,7 @@ fi
 
 
 ### Final container stage ###
-FROM alpine:latest
+FROM alpine:3.11
 
 LABEL description="GoHub Direct Connect Hub"
 
@@ -56,6 +61,9 @@ EXPOSE 1411
 # The HubStats port (TCP), be careful exposing this to the internet
 EXPOSE 2112
 
+# The pprof profiling port (TCP), be careful exposing this to the internet
+EXPOSE 6060
+
 # The default admin username and password (only used on the first run)
 ENV ADMIN_USER="admin"
 # Empty password means generate a random password on the first run
@@ -63,14 +71,15 @@ ENV ADMIN_PASSWORD=""
 
 # The arguments to pass to go-hub serve
 CMD []
-ENTRYPOINT ["go-dcpp"]
+ENTRYPOINT ["go-dcpp.sh"]
 
 # Run this command periodically to make sure everything is working
-# Disabled by default since it clogs up the container logs
+# Disabled by default since it clogs up the hub logs with connects and
+# disconnects from the pinger
 #HEALTHCHECK CMD dcping ping 127.0.0.1:1411
 
 # Copy go-hub and dcping from the build stage
-COPY --from=build /go/bin/dcping /go/bin/go-hub /bin/go-dcpp /bin/
+COPY --from=build /go/bin/dcping /go/bin/go-hub /bin/go-dcpp.sh /bin/
 
 # The GoHub user and group to run as (change with docker run -u)
 USER 888:888

--- a/filelist/filelist.go
+++ b/filelist/filelist.go
@@ -6,7 +6,7 @@ import (
 	"io"
 
 	"github.com/direct-connect/go-dc/tiger"
-	"github.com/direct-connect/go-dcpp/adc/types"
+	"github.com/direct-connect/go-dc/adc/types"
 )
 
 type Dir struct {

--- a/hub/hub_nmdc.go
+++ b/hub/hub_nmdc.go
@@ -44,14 +44,14 @@ func (h *Hub) ServeNMDC(conn net.Conn, cinfo *ConnInfo) error {
 	cntConnNMDCOpen.Add(1)
 	defer cntConnNMDCOpen.Add(-1)
 
+	if cinfo == nil {
+		cinfo = &ConnInfo{Local: conn.LocalAddr(), Remote: conn.RemoteAddr()}
+	}
 	if cinfo.TLSVers != 0 {
 		cntConnNMDCS.Add(1)
 	}
 	if cinfo.ALPN != "" {
 		cntConnAlpnNMDC.Add(1)
-	}
-	if cinfo == nil {
-		cinfo = &ConnInfo{Local: conn.LocalAddr(), Remote: conn.RemoteAddr()}
 	}
 
 	log.Printf("%s: using NMDC", conn.RemoteAddr())

--- a/start-docker.sh
+++ b/start-docker.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+die() {
+    echo "$2" >&2
+    exit $1
+}
+
+set -e
+
+# If the hub config file doesn't exist, initialize the hub
+if [ ! -e "hub.yml" ]; then
+    echo "--- Starting GoHub setup ---"
+    echo
+
+    go-hub init || \
+        die $? "Failed to initialize hub"
+
+    # Default admin user/pass (don't override if already set)
+    ADMIN=${ADMIN_USER:-admin}
+    PASS=${ADMIN_PASSWORD:-$(pwgen -s 12 1)}
+
+    go-hub user add "${ADMIN}" "${PASS}" root || \
+        die $? "Failed to create admin user"
+
+    printf '%s\n' \
+        "Username: ${ADMIN}" \
+        "Password: ${PASS}" \
+        "" \
+        "To add another admin, run the following (container must be running):" \
+        "docker exec container_name \\" \
+        "  go-hub user create \"new-admin\" \"new-password\" root" \
+    | tee admin.txt
+
+    echo
+    echo "--- Finished GoHub setup ---"
+    echo
+fi
+
+exec go-hub serve "$@" || \
+    die $? "Failed to start go-hub: $?"


### PR DESCRIPTION
There are 4 changes in this pull request:

1. Fix building `./...` from the go-dcpp root by removing the unused `filelist` module.  It was including the "go-dcpp/adc/types" module instead of "go-dc/adc/types" (it got moved, direct-connect/go-dc#21).

2. Add a Dockerfile and start script.

3. Add a GitHub Action to automatically build the go-dcpp docker container for every push and every pull request.

4. Fixed a nil pointer dereference in `ServeNMDC()`, exposed by the hub tests.